### PR TITLE
Fix stray token in pronoun click handler

### DIFF
--- a/public/js/handlers/events.js
+++ b/public/js/handlers/events.js
@@ -42,7 +42,7 @@ const handlePlaceholderClick = (internalType, displayName) => {
     } else {
         // For specialized types that have their own modal chains
         if (internalType === "PRONOUN") {
-            pickPronounFormAndGroup();node
+            pickPronounFormAndGroup();
             $('#placeholderSearch').val('');
             updatePlaceholderAccordion('#placeholderAccordion', '#noResults', state.currentPlaceholderSearch);
             // Hide the accordion container after selecting


### PR DESCRIPTION
## Summary
- remove leftover debug text from pronoun placeholder handler

## Testing
- `npm install`
- `npm run build` *(fails: Cannot find module 'semver/semver.js')*

------
https://chatgpt.com/codex/tasks/task_e_684e6a3759b08329b1accc646f613285